### PR TITLE
Fix TLS host mismatch

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -58,5 +58,5 @@ spec:
         pathType: Prefix
   tls:
   - hosts:
-    - github-k8s-example.ns1lab.net
+    - github-k8s-example.c0.ns1lab.net
     secretName: github-k8s-example.c0.ns1lab.net-tls


### PR DESCRIPTION
## Summary
- fix TLS host mismatch in `deployment.yaml`

## Testing
- `pytest -q`
- `yamllint deployment.yaml` (fails: wrong indentation)

------
https://chatgpt.com/codex/tasks/task_e_683f5fe6fb84832b9ed1a4629cb23460