### PR TITLE
feat: parameterize deployment and python version

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -8,6 +8,11 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  SERVICE_NAME: github-k8s-example
+  NAMESPACE: test
+  APPLICATION_PORT: 5000
+  REPLICAS: 2
+  PYTHON_VERSION: 3.12
 
 jobs:
   publish-docker-image:
@@ -42,6 +47,8 @@ jobs:
           push: true   # Push the built Docker image to GitHub Packages
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
 
   deploy:
     needs: publish-docker-image
@@ -56,4 +63,4 @@ jobs:
         echo "$KUBECONFIG_CONTENT" > $HOME/.kube/config
     - name: Deploy to Kubernetes
       run: |
-        kubectl apply -f deployment.yaml
+        envsubst < deployment.yaml | kubectl apply -f -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Dockerfile
-FROM python:3.8-slim-buster
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
 

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -2,61 +2,64 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hello-world
+  name: ${SERVICE_NAME}
+  namespace: ${NAMESPACE}
 spec:
-  replicas: 2
+  replicas: ${REPLICAS}
   selector:
     matchLabels:
-      app: hello-world
+      app: ${SERVICE_NAME}
   template:
     metadata:
       labels:
-        app: hello-world
+        app: ${SERVICE_NAME}
     spec:
       containers:
-      - name: hello-world
-        image: ghcr.io/ynotopec/github-k8s-example:main
+      - name: ${SERVICE_NAME}
+        image: ghcr.io/ynotopec/${SERVICE_NAME}:main
         ports:
-        - containerPort: 5000
+        - containerPort: ${APPLICATION_PORT}
 ---
 # service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: hello-world-service
+  name: ${SERVICE_NAME}-service
+  namespace: ${NAMESPACE}
 spec:
   type: ClusterIP
   selector:
-    app: hello-world
+    app: ${SERVICE_NAME}
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 5000
+    targetPort: ${APPLICATION_PORT}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: ${SERVICE_NAME}.c0.ns1lab.net
+  namespace: ${NAMESPACE}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/session-cookie-hash: sha1
     nginx.ingress.kubernetes.io/session-cookie-name: route
-  name: github-k8s-example.c0.ns1lab.net
 spec:
   ingressClassName: public
   rules:
-  - host: github-k8s-example.c0.ns1lab.net
+  - host: ${SERVICE_NAME}.c0.ns1lab.net
     http:
       paths:
       - backend:
           service:
-            name: hello-world-service
+            name: ${SERVICE_NAME}-service
             port:
               number: 80
         path: /
         pathType: Prefix
   tls:
   - hosts:
-    - github-k8s-example.c0.ns1lab.net
-    secretName: github-k8s-example.c0.ns1lab.net-tls
+    - ${SERVICE_NAME}.c0.ns1lab.net
+    secretName: ${SERVICE_NAME}.c0.ns1lab.net-tls

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 serverAddress=$1
 portNumber=$2
 
-pythonVersion=python3
+pythonVersion=python${PYTHON_VERSION:-3}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pythonDir=~/"venv/$(basename "${DIR}")"


### PR DESCRIPTION
## Summary
- allow selecting Python version via build ARG and run script
- template Kubernetes resources with environment variables for service details
- pass deployment variables through CI workflow

## Testing
- `/usr/bin/python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c135334d70832b9b23b7c3aa36d5a2