### PR TITLE
chore: clean run script and format app

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask import Flask
 app = Flask(__name__)
 
 
-@app.route('/')
+@app.route("/")
 def hello_world():
     """Return a greeting message.
 
@@ -14,7 +14,7 @@ def hello_world():
     return os.getenv("MESSAGE", "Hello, World!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "5000"))
     app.run(host=host, port=port)

--- a/run.sh
+++ b/run.sh
@@ -1,44 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-serverAddress=$1
-portNumber=$2
+server_address=${1:-}
+port_number=${2:-}
+python_version=python3
 
-pythonVersion=python3
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python_dir="${HOME}/venv/$(basename "${DIR}")"
+cd "${DIR}"
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-pythonDir=~/"venv/$(basename "${DIR}")"
-cd $DIR
-
-deactivate 2>/dev/null
-mkdir -p "${pythonDir}"
-${pythonVersion} -m venv "${pythonDir}"
-source "${pythonDir}"/bin/activate
-
-#intall
-${pythonVersion} -m pip cache purge
-${pythonVersion} -m pip install -U pip setuptools wheel
-${pythonVersion} -m pip install -U -r requirements.txt
-#optimize space
-#(jdupes -X size+:99M -r -L ~ >/dev/null 2>&1 )&
-
-export HF_HUB_DISABLE_TELEMETRY=1
-if [ ! -z "${serverAddress}" ] ;then
-  export GRADIO_SERVER_NAME="${serverAddress}"
-  export SERVER_NAME="${serverAddress}"
-  export HOST="${serverAddress}"
+if [ ! -d "${python_dir}" ]; then
+  "${python_version}" -m venv "${python_dir}"
 fi
-if [ ! -z "${portNumber}" ] ;then
-  export GRADIO_SERVER_PORT="${portNumber}"
-  export SERVER_PORT="${portNumber}"
-  export BACK_PORT=$((SERVER_PORT + 1))
-  export PORT="${portNumber}"
-fi
-export CUDA_LAUNCH_BLOCKING=1
+# shellcheck disable=SC1091
+source "${python_dir}/bin/activate"
 
-# Charger les variables d'environnement depuis .env
+"${python_version}" -m pip install --upgrade pip setuptools wheel
+"${python_version}" -m pip install --upgrade -r requirements.txt
+
 if [ -f ".env" ]; then
-#  export $(grep -v '^#' .env | xargs)
   set -a
+  # shellcheck disable=SC1091
   source .env
   set +a
 else
@@ -46,7 +28,11 @@ else
   exit 1
 fi
 
-${pythonVersion} app.py $([ ! -z "${serverAddress}" ] && echo --host ${serverAddress}) $([ ! -z "${portNumber}" ] && echo --port ${portNumber})
-#${pythonVersion} -m streamlit run app.py --browser.gatherUsageStats false $([ ! -z "${serverAddress}" ] && echo --server.address ${serverAddress}) $([ ! -z "${portNumber}" ] && echo --server.port ${portNumber})
-#${pythonVersion} -m uvicorn app:app --reload $([ ! -z "${serverAddress}" ] && echo --host ${serverAddress}) $([ ! -z "${portNumber}" ] && echo --port ${portNumber})
-#${pythonVersion} back.py
+if [ -n "${server_address}" ]; then
+  export HOST="${server_address}"
+fi
+if [ -n "${port_number}" ]; then
+  export PORT="${port_number}"
+fi
+
+exec "${python_version}" app.py


### PR DESCRIPTION
## Summary
- simplify run script with venv setup and safer defaults
- format app entrypoint with Black

## Testing
- `shellcheck run.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1427fc3bc832b92414b11876bd2d9